### PR TITLE
Develop

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -124,7 +124,8 @@ class WebSocketAwait extends WebSocket {
                         this.emit('messageAwait', parseData, awaitId);
                         return;
                     }
-                    const {resolve} = this.getAwaitId(awaitId);
+                    // eslint-disable-next-line prefer-destructuring
+                    const resolve = this.getAwaitId(awaitId).resolve;
                     this.deleteAwaitId(awaitId);
                     if (!this.leaveAwaitId) {
                         delete parseData.awaitId;
@@ -139,7 +140,8 @@ class WebSocketAwait extends WebSocket {
         });
         socket.on('close', () => {
             for (const item of this.waitingReplies) {
-                const {reject} = this.getAwaitId(item[0]);
+                // eslint-disable-next-line prefer-destructuring
+                const reject = this.getAwaitId(item[0]).reject;
                 reject(new Error('The message is not sent or not response is received: Connection close'));
                 this.deleteAwaitId(item[0]);
             }
@@ -217,7 +219,8 @@ class WebSocketAwait extends WebSocket {
      * @private
      */
     deleteAwaitId(awaitId) {
-        const {timeout} = this.waitingReplies.get(awaitId);
+        // eslint-disable-next-line prefer-destructuring
+        const timeout = this.waitingReplies.get(awaitId).timeout;
         clearTimeout(timeout);
         this.waitingReplies.delete(awaitId);
     }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -27,9 +27,6 @@ class WebSocketAwait extends WebSocket {
         this.extractAwaitId = data => data &&
             Object.prototype.hasOwnProperty.call(data, this.nameAwaitId) && data[this.nameAwaitId];
         this.waitingReplies = new Map();
-        this.resolvesObj = {};
-        this.rejectsObj = {};
-        this.timeoutsObj = {};
     }
 
     /**
@@ -113,29 +110,39 @@ class WebSocketAwait extends WebSocket {
         super.setSocket(socket, head, maxPayload);
         this._receiver.removeAllListeners('message');
         this._receiver.on('message', data => {
-            let parseData = data;
-            if (this.unpackMessage && typeof this.unpackMessage === 'function') {
-                parseData = this.unpackMessage(data);
-            }
-            const awaitId = this.extractAwaitId(parseData);
-            if (awaitId) {
-                if (!this.checkAwaitId(awaitId)) {
+            try {
+                let parseData = data;
+                if (this.unpackMessage && typeof this.unpackMessage === 'function') {
+                    parseData = this.unpackMessage(data);
+                }
+                const awaitId = this.extractAwaitId(parseData);
+                if (awaitId) {
+                    if (!this.checkAwaitId(awaitId)) {
+                        if (!this.leaveAwaitId) {
+                            delete parseData.awaitId;
+                        }
+                        this.emit('messageAwait', parseData, awaitId);
+                        return;
+                    }
+                    const {resolve} = this.getAwaitId(awaitId);
+                    this.deleteAwaitId(awaitId);
                     if (!this.leaveAwaitId) {
                         delete parseData.awaitId;
                     }
-                    this.emit('messageAwait', parseData, awaitId);
+                    resolve(parseData);
                     return;
                 }
-                // eslint-disable-next-line prefer-destructuring
-                const resolve = this.getAwaitId(awaitId).resolve;
-                this.deleteAwaitId(awaitId);
-                if (!this.leaveAwaitId) {
-                    delete parseData.awaitId;
-                }
-                resolve(parseData);
-                return;
+                this.emit('message', parseData);
+            } catch (error) {
+                this.emit('error', new Error(`The message received but not processed: ${error.message}, ${data}`));
             }
-            this.emit('message', parseData);
+        });
+        socket.on('close', () => {
+            for (const item of this.waitingReplies) {
+                const {reject} = this.getAwaitId(item[0]);
+                reject(new Error('The message is not sent or not response is received: Connection close'));
+                this.deleteAwaitId(item[0]);
+            }
         });
     }
 
@@ -163,18 +170,20 @@ class WebSocketAwait extends WebSocket {
      * Saving the identification parameter and setting the timer to auto-complete(reject) and delete.
      *
      * @param {String} awaitId identification parameter
-     * @param {Object} resolve Resolve object
-     * @param {Object} reject Reject object
+     * @param {Function} resolve is resolve function
+     * @param {Function} reject is reject function
      * @private
      */
     setAwaitId(awaitId, resolve, reject) {
-        this.waitingReplies.set(awaitId);
-        this.resolvesObj[awaitId] = resolve;
-        this.rejectsObj[awaitId] = reject;
-        this.timeoutsObj[awaitId] = setTimeout(() => {
+        const timeout = setTimeout(() => {
             this.deleteAwaitId(awaitId);
-            reject(new Error('The message is not received: Response timeout expired'));
+            reject(new Error('The message is not sent or no response is received: Response timeout expired'));
         }, 1000 * this.awaitTimeout);
+        this.waitingReplies.set(awaitId, {
+            resolve,
+            reject,
+            timeout,
+        });
     }
 
     /**
@@ -189,14 +198,16 @@ class WebSocketAwait extends WebSocket {
     }
 
     /**
-     * Getting by identification parameter resolve/reject object
+     * Getting by identification parameter object containing the functions for this identifier
      *
      * @param {String} awaitId identification parameter
-     * @return {Object} resolve/reject object
+     * @return {Object} is on an object containing the functions for this identifier
+     * @return {Function} Object.resolve is resolve function
+     * @return {Function} Object.reject is reject function
      * @private
      */
     getAwaitId(awaitId) {
-        return {resolve: this.resolvesObj[awaitId], reject: this.rejectsObj[awaitId]};
+        return this.waitingReplies.get(awaitId);
     }
 
     /**
@@ -206,11 +217,9 @@ class WebSocketAwait extends WebSocket {
      * @private
      */
     deleteAwaitId(awaitId) {
-        clearTimeout(this.timeoutsObj[awaitId]);
-        delete this.timeoutsObj[awaitId];
+        const {timeout} = this.waitingReplies.get(awaitId);
+        clearTimeout(timeout);
         this.waitingReplies.delete(awaitId);
-        delete this.resolvesObj[awaitId];
-        delete this.rejectsObj[awaitId];
     }
 
     /**
@@ -237,7 +246,7 @@ class WebSocketAwait extends WebSocket {
                 }
                 this.setAwaitId(awaitId, resolve, reject);
             } catch (err) {
-                reject(new Error(`The message is not received: ${err.message}`));
+                reject(new Error(`The message is not sent or no response is received: ${err.message}`));
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-await",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Modification of the module ws to wait for a response",
   "keywords": [
     "WebSocket",

--- a/test/WebSocketAwait.test.js
+++ b/test/WebSocketAwait.test.js
@@ -134,45 +134,6 @@ describe('WebSocketAwait', () => {
                     }
                 );
             });
-            it('resolvesObj option in constructor', done => {
-                const wss = new WebSocketAwait.Server(
-                    {port: 0},
-                    () => {
-                        const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
-                        ws.onopen = () => {
-                            assert.deepStrictEqual(typeof ws.resolvesObj, 'object');
-                            assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                            wss.close(done);
-                        };
-                    }
-                );
-            });
-            it('rejectsObj option in constructor', done => {
-                const wss = new WebSocketAwait.Server(
-                    {port: 0},
-                    () => {
-                        const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
-                        ws.onopen = () => {
-                            assert.deepStrictEqual(typeof ws.rejectsObj, 'object');
-                            assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                            wss.close(done);
-                        };
-                    }
-                );
-            });
-            it('timeoutsObj option in constructor', done => {
-                const wss = new WebSocketAwait.Server(
-                    {port: 0},
-                    () => {
-                        const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
-                        ws.onopen = () => {
-                            assert.deepStrictEqual(typeof ws.timeoutsObj, 'object');
-                            assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                            wss.close(done);
-                        };
-                    }
-                );
-            });
         });
         describe('check the functions of the module in the module settings', () => {
             describe('generateAwaitId function', () => {
@@ -660,7 +621,7 @@ describe('WebSocketAwait', () => {
                     wss.on('connection', ws => {
                         ws.on('message', msg => {
                             assert.deepStrictEqual(msg, testData.default);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -679,7 +640,7 @@ describe('WebSocketAwait', () => {
                         });
                         ws.on('message', msg => {
                             assert.deepStrictEqual(msg, testData.defaultJSON);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -702,7 +663,7 @@ describe('WebSocketAwait', () => {
                         ws.on('message', msg => {
                             assert.strictEqual(typeof msg, 'object');
                             assert.strictEqual(Object.keys(msg).length, 0);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -751,16 +712,17 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
                     ws.onopen = () => {
                         ws.sendAwait(testData.default);
+                        for (const item of ws.waitingReplies) {
+                            assert.strictEqual(typeof item[0], 'string');
+                            assert.deepStrictEqual(Object.keys(item[1]), ['resolve', 'reject', 'timeout']);
+                        }
                         assert.strictEqual(ws.waitingReplies.size, 1);
-                        assert.strictEqual(Object.keys(ws.resolvesObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.rejectsObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.timeoutsObj).length, 1);
                     };
                 });
         });
@@ -773,7 +735,7 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -782,10 +744,11 @@ describe('WebSocketAwait', () => {
                             throw new Error('The event should not fire if there is a resolve object')
                         });
                         ws.sendAwait(testData.default);
+                        for (const item of ws.waitingReplies) {
+                            assert.strictEqual(typeof item[0], 'string');
+                            assert.deepStrictEqual(Object.keys(item[1]), ['resolve', 'reject', 'timeout']);
+                        }
                         assert.strictEqual(ws.waitingReplies.size, 1);
-                        assert.strictEqual(Object.keys(ws.resolvesObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.rejectsObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.timeoutsObj).length, 1);
                     };
                 });
         });
@@ -798,7 +761,7 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -806,10 +769,11 @@ describe('WebSocketAwait', () => {
                         ws.sendAwait(testData.default, () => {
                             throw new Error('Callback is passed to sendAwait method')
                         });
+                        for (const item of ws.waitingReplies) {
+                            assert.strictEqual(typeof item[0], 'string');
+                            assert.deepStrictEqual(Object.keys(item[1]), ['resolve', 'reject', 'timeout']);
+                        }
                         assert.strictEqual(ws.waitingReplies.size, 1);
-                        assert.strictEqual(Object.keys(ws.resolvesObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.rejectsObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.timeoutsObj).length, 1);
                     };
                 });
         });
@@ -822,16 +786,17 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
                     ws.onopen = () => {
                         ws.sendAwait(testData.default, {});
+                        for (const item of ws.waitingReplies) {
+                            assert.strictEqual(typeof item[0], 'string');
+                            assert.deepStrictEqual(Object.keys(item[1]), ['resolve', 'reject', 'timeout']);
+                        }
                         assert.strictEqual(ws.waitingReplies.size, 1);
-                        assert.strictEqual(Object.keys(ws.resolvesObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.rejectsObj).length, 1);
-                        assert.strictEqual(Object.keys(ws.timeoutsObj).length, 1);
                     };
                 });
         });
@@ -849,11 +814,42 @@ describe('WebSocketAwait', () => {
                         ws.sendAwait(testData.default)
                             .catch(err => {
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                                assert.strictEqual(err.message, 'The message is not received: Test');
-                                wss.close(done);
+                                assert.strictEqual(err.message, 'The message is not sent or no response is received: Test');
+                                done();
+                            });
+                    };
+                });
+        });
+        it('sendAwait with data {Object} and error in unpackMessage', done => {
+            const wss = new WebSocketAwait.Server(
+                {port: 0},
+                () => {
+                    wss.on('connection', ws => {
+                        ws.on('messageAwait', (msg, id) => {
+                            assert.strictEqual(typeof id, 'string');
+                            assert.strictEqual(typeof msg, 'object');
+                            assert.deepStrictEqual(Object.keys(msg), ['foo']);
+                            ws.resAwait(testData.default, id);
+                        });
+                    });
+                    const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
+                    ws.setSettings({
+                        unpackMessage: () => {
+                            throw new Error('Test');
+                        },
+                    });
+                    ws.onerror = err => {
+                        assert.strictEqual(typeof err.message, 'string');
+                        assert.strictEqual(err.message.length > 0, true);
+                        done();
+                    };
+                    ws.onopen = () => {
+                        ws.sendAwait(testData.default)
+                            .then(waiting => {
+                                throw new Error(`This test without Waiting: ${waiting}`);
+                            })
+                            .catch(err => {
+                                throw new Error(`This test without Errors: ${err}`);
                             });
                     };
                 });
@@ -870,10 +866,7 @@ describe('WebSocketAwait', () => {
                         ws.sendAwait(testData.default)
                             .catch(err => {
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                                assert.strictEqual(err.message, 'The message is not received: Response timeout expired');
+                                assert.strictEqual(err.message, 'The message is not sent or no response is received: Response timeout expired');
                                 wss.close(done);
                             });
                     };
@@ -886,11 +879,31 @@ describe('WebSocketAwait', () => {
             ws.sendAwait(testData.default)
                 .catch(err => {
                     assert.strictEqual(ws.waitingReplies.size, 0);
-                    assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                    assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                    assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                    assert.strictEqual(err.message, 'The message is not received: WebSocket is not open: readyState 0 (CONNECTING)');
+                    assert.strictEqual(err.message, 'The message is not sent or no response is received: WebSocket is not open: readyState 0 (CONNECTING)');
                     done();
+                });
+        });
+        it('sendAwait with data {Object} and with WebSocket is closed by server after get messageAwait', done => {
+            const wss = new WebSocketAwait.Server(
+                {port: 0},
+                () => {
+                    wss.on('connection', ws => {
+                        ws.on('messageAwait', (msg, id) => {
+                            assert.strictEqual(typeof id, 'string');
+                            assert.strictEqual(typeof msg, 'object');
+                            assert.deepStrictEqual(Object.keys(msg), ['foo']);
+                            ws.close();
+                        });
+                    });
+                    const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
+                    ws.onopen = () => {
+                        ws.sendAwait(testData.default)
+                            .catch(err => {
+                                assert.strictEqual(ws.waitingReplies.size, 0);
+                                assert.strictEqual(err.message, 'The message is not sent or not response is received: Connection close');
+                                done();
+                            });
+                    };
                 });
         });
         it('sendAwait with data {Object} and await waiting', done => {
@@ -911,10 +924,7 @@ describe('WebSocketAwait', () => {
                             .then(waiting => {
                                 assert.deepStrictEqual(waiting, testData.default);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                                wss.close(done);
+                                done();
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -951,10 +961,7 @@ describe('WebSocketAwait', () => {
                                 assert.strictEqual(typeof waiting.foo, 'number');
                                 assert.deepStrictEqual(Object.keys(waiting), ['testId', 'foo']);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                                wss.close(done);
+                                done();
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -989,10 +996,7 @@ describe('WebSocketAwait', () => {
                                 assert.strictEqual(typeof waiting.foo, 'number');
                                 assert.deepStrictEqual(Object.keys(waiting), ['awaitId', 'foo']);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
-                                wss.close(done);
+                                done();
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -1011,7 +1015,7 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -1021,9 +1025,6 @@ describe('WebSocketAwait', () => {
                             .then(status => {
                                 assert.strictEqual(awaitId, status);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -1040,7 +1041,7 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -1052,9 +1053,6 @@ describe('WebSocketAwait', () => {
                             .then(status => {
                                 assert.strictEqual(awaitId, status);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -1071,7 +1069,7 @@ describe('WebSocketAwait', () => {
                             assert.strictEqual(typeof id, 'string');
                             assert.strictEqual(typeof msg, 'object');
                             assert.deepStrictEqual(Object.keys(msg), ['foo']);
-                            wss.close(done);
+                            done();
                         });
                     });
                     const ws = new WebSocketAwait(`ws://localhost:${wss.address().port}`);
@@ -1081,9 +1079,6 @@ describe('WebSocketAwait', () => {
                             .then(status => {
                                 assert.strictEqual(awaitId, status);
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
                             })
                             .catch(err => {
                                 throw new Error(`This test without Errors: ${err}`);
@@ -1105,11 +1100,8 @@ describe('WebSocketAwait', () => {
                         ws.resAwait(testData.default)
                             .catch(err => {
                                 assert.strictEqual(ws.waitingReplies.size, 0);
-                                assert.strictEqual(Object.keys(ws.resolvesObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.rejectsObj).length, 0);
-                                assert.strictEqual(Object.keys(ws.timeoutsObj).length, 0);
                                 assert.strictEqual(err.message, 'The message is not received: Test');
-                                wss.close(done);
+                                done();
                             });
                     };
                 });


### PR DESCRIPTION
- Remove resolvesObj, rejectsObj, timeoutsObj. Now they are stored in waitingReplies.
- The received message processing block is now wrapped in try/catch. In case of an error, an `error` event is generated 
in this block (contains an error message and the message being processed).
- Now, when you close the connection, all pending messages sent will receive a reject with text `The message is not sent
 or not response is received: Connection close`. All timers will be reset.
- If there is an error in the method `sendAwait` text changed to `The message is not sent or no response is received:` +
`error.message`.
- Modified jsdoc for some methods.
- Changed old tests under a new change and a new written.